### PR TITLE
Properly center armor icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
     <img src="https://img.shields.io/github/downloads/legoraft/simple-armor-hud/total" alt="Github downloads"/>
 </p>
 
+(Fork with properly centered armor display)
+
 ## Information
 This mod shows your armor above the foodbar in the in-game hud. It also moves armor up when underwater and down when in creative and has a few config options for compatibility with other mods. You can toggle the armor hud on or off with a keybind, configurable through the normal menu.
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
     <img src="https://img.shields.io/github/downloads/legoraft/simple-armor-hud/total" alt="Github downloads"/>
 </p>
 
-(Fork with properly centered armor display)
-
 ## Information
 This mod shows your armor above the foodbar in the in-game hud. It also moves armor up when underwater and down when in creative and has a few config options for compatibility with other mods. You can toggle the armor hud on or off with a keybind, configurable through the normal menu.
 

--- a/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
+++ b/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
@@ -23,7 +23,8 @@ public abstract class armorHudMixin {
 	@Shadow private int scaledWidth;
 	@Shadow private int scaledHeight;
 	@Shadow protected abstract LivingEntity getRiddenEntity();
-	int armorHeight;
+
+	@Unique int armorHeight;
 
 	@Inject(at = @At("TAIL"), method = "renderHotbar")
 	private void renderHud(float tickDelta, DrawContext context, CallbackInfo ci) {


### PR DESCRIPTION
Centered the armor icons properly above the hunger bar

This is what it looked like for me before:
![not-centered](https://github.com/legoraft/simple-armor-hud/assets/79479264/b265e0f8-2bd4-4a27-bb66-5bbb78b3d3e8)
_(Bug and fix verified on fabric 1.20.2)_