### PR TITLE
Updated to 1.21 and refactored some things

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
 	maven { url = "https://maven.terraformersmc.com/" }
-	maven { url = "https://maven.gegy.dev" }
+//	maven { url = "https://maven.gegy.dev" }
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.3
+minecraft_version=1.21
+yarn_mappings=1.21+build.1
 loader_version=0.15.11
 
 # Mod Properties
@@ -14,5 +14,5 @@ maven_group=com.armorhud
 archives_base_name=simple-armor-hud
 
 # Dependency properties
-fabric_version=0.99.0+1.20.6
-modmenu_version=10.0.0-beta.1
+fabric_version=0.100.1+1.21
+modmenu_version=11.0.0-beta.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,14 +5,14 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21
-yarn_mappings=1.21+build.1
+yarn_mappings=1.21+build.2
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.4.3
+mod_version=1.4.4
 maven_group=com.armorhud
 archives_base_name=simple-armor-hud
 
 # Dependency properties
-fabric_version=0.100.1+1.21
-modmenu_version=11.0.0-beta.1
+fabric_version=0.100.3+1.21
+modmenu_version=11.0.1

--- a/src/client/java/com/armorhud/config/configScreen.java
+++ b/src/client/java/com/armorhud/config/configScreen.java
@@ -5,10 +5,10 @@ import net.minecraft.client.gui.screen.option.GameOptionsScreen;
 import net.minecraft.client.gui.widget.*;
 import net.minecraft.text.Text;
 
-public class fabricScreen extends GameOptionsScreen {
+public class configScreen extends GameOptionsScreen {
     public Screen parent;
 
-    public fabricScreen(Screen parent) {
+    public configScreen(Screen parent) {
         super(parent, null, Text.translatable("config.title"));
 
         this.parent = parent;

--- a/src/client/java/com/armorhud/config/configScreen.java
+++ b/src/client/java/com/armorhud/config/configScreen.java
@@ -1,5 +1,6 @@
 package com.armorhud.config;
 
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.GameOptionsScreen;
 import net.minecraft.client.gui.widget.*;
@@ -18,8 +19,9 @@ public class configScreen extends GameOptionsScreen {
     public CyclingButtonWidget betterMountHudToggle;
     public CyclingButtonWidget armorHudToggle;
     public CyclingButtonWidget rightToLeftToggle;
-
     public CyclingButtonWidget disableArmorBar;
+
+    public ButtonWidget doneButton;
 
     @Override
     protected void init() {
@@ -43,6 +45,19 @@ public class configScreen extends GameOptionsScreen {
         optionListWidget.addWidgetEntry(doubleHotbarToggle, betterMountHudToggle);
         optionListWidget.addWidgetEntry(armorHudToggle, rightToLeftToggle);
         optionListWidget.addWidgetEntry(disableArmorBar, null);
+
+        doneButton = ButtonWidget
+                .builder(Text.translatable("config.done"), button -> close())
+                .dimensions(width / 2 - 100, height - 25, 200, 20)
+                .build();
+
+        addDrawableChild(doneButton);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        super.render(context, mouseX, mouseY, delta);
+        context.drawCenteredTextWithShadow(textRenderer, super.title, width / 2, 10, 0xffffff);
     }
 
     @Override

--- a/src/client/java/com/armorhud/config/configScreen.java
+++ b/src/client/java/com/armorhud/config/configScreen.java
@@ -57,7 +57,7 @@ public class configScreen extends GameOptionsScreen {
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         super.render(context, mouseX, mouseY, delta);
-        context.drawCenteredTextWithShadow(textRenderer, super.title, width / 2, 10, 0xffffff);
+        context.drawCenteredTextWithShadow(textRenderer, super.title, width / 2, 12, 0xffffff);
     }
 
     @Override

--- a/src/client/java/com/armorhud/config/fabricScreen.java
+++ b/src/client/java/com/armorhud/config/fabricScreen.java
@@ -23,7 +23,7 @@ public class fabricScreen extends GameOptionsScreen {
 
     @Override
     protected void init() {
-        OptionListWidget optionListWidget = this.addDrawableChild(new OptionListWidget(this.client, this.width, this.height, this));
+        OptionListWidget optionListWidget = this.addDrawableChild(new OptionListWidget(this.client, this.width, this));
 
         doubleHotbarToggle = CyclingButtonWidget.onOffBuilder(config.DOUBLE_HOTBAR)
                 .build(Text.translatable("config.doublehotbar"), ((button, value) -> config.DOUBLE_HOTBAR = !config.DOUBLE_HOTBAR));
@@ -44,6 +44,11 @@ public class fabricScreen extends GameOptionsScreen {
         optionListWidget.addWidgetEntry(armorHudToggle, rightToLeftToggle);
         optionListWidget.addWidgetEntry(disableArmorBar, null);
         super.init();
+    }
+
+    @Override
+    protected void addOptions() {
+
     }
 
     @Override

--- a/src/client/java/com/armorhud/config/fabricScreen.java
+++ b/src/client/java/com/armorhud/config/fabricScreen.java
@@ -23,8 +23,6 @@ public class fabricScreen extends GameOptionsScreen {
 
     @Override
     protected void init() {
-        OptionListWidget optionListWidget = this.addDrawableChild(new OptionListWidget(this.client, this.width, this));
-
         doubleHotbarToggle = CyclingButtonWidget.onOffBuilder(config.DOUBLE_HOTBAR)
                 .build(Text.translatable("config.doublehotbar"), ((button, value) -> config.DOUBLE_HOTBAR = !config.DOUBLE_HOTBAR));
 
@@ -38,17 +36,18 @@ public class fabricScreen extends GameOptionsScreen {
                 .build(Text.translatable("config.righttoleft"), (button, value) -> config.RTL = !config.RTL);
 
         disableArmorBar = CyclingButtonWidget.onOffBuilder(config.DISABLE_ARMOR_BAR)
-                        .build(Text.translatable("config.disablearmorbar"), ((button, value) -> config.DISABLE_ARMOR_BAR = !config.DISABLE_ARMOR_BAR));
+                .build(Text.translatable("config.disablearmorbar"), ((button, value) -> config.DISABLE_ARMOR_BAR = !config.DISABLE_ARMOR_BAR));
+
+        OptionListWidget optionListWidget = this.addDrawableChild(new OptionListWidget(this.client, this.width, this));
 
         optionListWidget.addWidgetEntry(doubleHotbarToggle, betterMountHudToggle);
         optionListWidget.addWidgetEntry(armorHudToggle, rightToLeftToggle);
         optionListWidget.addWidgetEntry(disableArmorBar, null);
-        super.init();
     }
 
     @Override
     protected void addOptions() {
-
+        super.init();
     }
 
     @Override

--- a/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
+++ b/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
@@ -69,24 +69,10 @@ public abstract class armorHudMixin {
 	private void renderArmorPiece(DrawContext context, float x, float y, RenderTickCounter tickCounter, PlayerEntity player, ItemStack stack) {
 		if (stack.isEmpty()) return;
 
-		// Magic
-		float f = (float)stack.getBobbingAnimationTime() - tickCounter.getTickDelta(false);
 		context.getMatrices().push();
 		context.getMatrices().translate(x, y, 0);
 
-		if (f > 0) {
-			float g = 1 + f / 5;
-			context.getMatrices().push();
-			context.getMatrices().translate(8, 12, 0);
-			context.getMatrices().scale(1 / g, (g + 1) / 2, 1);
-			context.getMatrices().translate(-8, -12, 0);
-		}
-
 		context.drawItem(player, stack, 0, 0, 1);
-
-		if (f > 0) {
-			context.getMatrices().pop();
-		}
 
 		context.drawItemInSlot(this.client.textRenderer, stack, 0,0);
 		context.getMatrices().pop();

--- a/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
+++ b/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
@@ -4,6 +4,7 @@ import com.armorhud.config.config;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -16,27 +17,28 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(InGameHud.class)
-
 public abstract class armorHudMixin {
 
 	@Shadow @Final private MinecraftClient client;
 
 	@Shadow protected abstract LivingEntity getRiddenEntity();
 
+	@Shadow public abstract void tick(boolean paused);
+
 	@Unique int armorHeight;
 
 	@Inject(at = @At("TAIL"), method = "renderHotbar")
-	private void renderHud(DrawContext context, float tickDelta, CallbackInfo ci) {
+	private void renderHud(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
 		if(!config.ARMOR_HUD) { return; }
 
 		assert client.player != null;
 
-		renderArmor(context, tickDelta);
+		renderArmor(context, tickCounter);
 		moveArmor(context);
 	}
 
 	@Unique
-	private void renderArmor(DrawContext context, float tickDelta) {
+	private void renderArmor(DrawContext context, RenderTickCounter tickCounter) {
 		int scaledWidth = context.getScaledWindowWidth();
 
 		assert client.player != null;
@@ -58,17 +60,17 @@ public abstract class armorHudMixin {
 				armorPiece = j;
 			}
 
-			renderArmorPiece(context, x, armorHeight, tickDelta, client.player, client.player.getInventory().getArmorStack(armorPiece));
+			renderArmorPiece(context, x, armorHeight, tickCounter, client.player, client.player.getInventory().getArmorStack(armorPiece));
 		}
 	}
 
 	// Pretty much the same as renderHotbarItem but with x and y as float parameters.
 	@Unique
-	private void renderArmorPiece(DrawContext context, float x, float y, float tickDelta, PlayerEntity player, ItemStack stack) {
+	private void renderArmorPiece(DrawContext context, float x, float y, RenderTickCounter tickCounter, PlayerEntity player, ItemStack stack) {
 		if (stack.isEmpty()) return;
 
 		// Magic
-		float f = (float)stack.getBobbingAnimationTime() - tickDelta;
+		float f = (float)stack.getBobbingAnimationTime() - tickCounter.getTickDelta(false);
 		context.getMatrices().push();
 		context.getMatrices().translate(x, y, 0);
 

--- a/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
+++ b/src/client/java/com/armorhud/mixin/client/armorHudMixin.java
@@ -81,7 +81,9 @@ public abstract class armorHudMixin {
 			context.getMatrices().scale(1 / g, (g + 1) / 2, 1);
 			context.getMatrices().translate(-8, -12, 0);
 		}
+
 		context.drawItem(player, stack, 0, 0, 1);
+
 		if (f > 0) {
 			context.getMatrices().pop();
 		}

--- a/src/client/java/com/armorhud/mixin/client/inGameHudMixin.java
+++ b/src/client/java/com/armorhud/mixin/client/inGameHudMixin.java
@@ -16,24 +16,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 public abstract class inGameHudMixin {
 
-//    @ModifyVariable(method = "renderArmor", at = @At("STORE"), ordinal = 1)
-//    private static int renderArmor(int l) {
-//
-//        if (config.DISABLE_ARMOR_BAR) {
-//            return 0;
-//        } else {
-//            return player.getArmor();
-//        }
-//    }
-
-    @Inject(method = "renderArmor", at=@At("HEAD"))
+    @Inject(method = "renderArmor", at=@At("HEAD"), cancellable = true)
     private static void checkArmor(DrawContext context, PlayerEntity player, int i, int j, int k, int x, CallbackInfo ci) {
-        int l;
-
         if (config.DISABLE_ARMOR_BAR) {
-            l = 0;
-        } else {
-            l = player.getArmor();
+            ci.cancel();
         }
     }
 

--- a/src/client/java/com/armorhud/mixin/client/inGameHudMixin.java
+++ b/src/client/java/com/armorhud/mixin/client/inGameHudMixin.java
@@ -1,29 +1,39 @@
 package com.armorhud.mixin.client;
 
 import com.armorhud.config.config;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.entity.player.PlayerEntity;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(InGameHud.class)
 
 public abstract class inGameHudMixin {
 
-    @Shadow @Nullable protected abstract PlayerEntity getCameraPlayer();
+//    @ModifyVariable(method = "renderArmor", at = @At("STORE"), ordinal = 1)
+//    private static int renderArmor(int l) {
+//
+//        if (config.DISABLE_ARMOR_BAR) {
+//            return 0;
+//        } else {
+//            return player.getArmor();
+//        }
+//    }
 
-    @ModifyVariable(method = "renderStatusBars", at = @At("STORE"), ordinal = 11)
-    public int renderStatusBars(int u) {
-        PlayerEntity playerEntity = this.getCameraPlayer();
-        assert playerEntity != null;
+    @Inject(method = "renderArmor", at=@At("HEAD"))
+    private static void checkArmor(DrawContext context, PlayerEntity player, int i, int j, int k, int x, CallbackInfo ci) {
+        int l;
 
         if (config.DISABLE_ARMOR_BAR) {
-            return 0;
+            l = 0;
         } else {
-            return playerEntity.getArmor();
+            l = player.getArmor();
         }
     }
 

--- a/src/client/java/com/armorhud/util/armorHudModMenu.java
+++ b/src/client/java/com/armorhud/util/armorHudModMenu.java
@@ -1,8 +1,8 @@
 package com.armorhud.util;
 
+import com.armorhud.config.configScreen;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
-import com.armorhud.config.fabricScreen;
 import net.minecraft.client.gui.screen.Screen;
 
 public class armorHudModMenu implements ModMenuApi {
@@ -13,7 +13,7 @@ public class armorHudModMenu implements ModMenuApi {
     }
 
     private Screen createConfigScreen(Screen parent) {
-        return new fabricScreen(parent);
+        return new configScreen(parent);
     }
 
 }


### PR DESCRIPTION
This pull request fixes everything that was mentioned in #44.

- Option screen now uses correct functions and is renamed to `configScreen`
- Armor bar disabling now just cancels the `renderArmorBar` function
- Some unnecessary code from PR #32 was removed
- The maven.gegy.dev was disabled, as spruceui is no longer used.